### PR TITLE
tweet一覧、新規作成ページの表示エラー解消

### DIFF
--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -3,7 +3,7 @@ class TweetsController < ApplicationController
 
   # GET /tweets or /tweets.json
   def index
-    @tweets = Tweet.al
+    @tweets = Tweet.all
   end
 
   # GET /tweets/1 or /tweets/1.json
@@ -12,7 +12,7 @@ class TweetsController < ApplicationController
 
   # GET /tweets/new
   def new
-    @tweet = Tweet.ew
+    @tweet = Tweet.new
   end
 
   # GET /tweets/1/edit


### PR DESCRIPTION
# what
「tweet一覧ページ(tweets/new)にアクセスするとNoMethodErrorとなる」解消
「tweet新規作成ページ(tweets/new)にアクセスするとNoMethodErrorとなる」解消

# why
一覧ページ、新規作成ページ遷移のため

allとnewが誤字だったため修正
一覧ページ(tweets/new)だったため102103を合わせて修正しています

@tweet = Tweet.al　→@tweet = Tweet.all
@tweet = Tweet.ew　→@tweet = Tweet.new